### PR TITLE
Update ODH 0.5.1 channel name from "alpha" to "legacy"

### DIFF
--- a/namespaces_and_operator_subscriptions/opendatahub/odh-operator-subscription.yaml
+++ b/namespaces_and_operator_subscriptions/opendatahub/odh-operator-subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
   name: opendatahub-operator
 spec:
-  channel: alpha
+  channel: legacy
   installPlanApproval: Automatic
   name: opendatahub-operator
   source: community-operators


### PR DESCRIPTION
ODH just release version 0.6.0 which changes the operator architecture
to handle kubeflow deployments.  There is no upgrade path from 0.5.z -> 0.6.0

The channel name for the 0.5.1 release was changed from "alpha" to "legacy"

