### PR TITLE
Enable Seldon metrics and monitoring

### DIFF
--- a/components/iot-anomaly-detection/AnomalyDetection.py
+++ b/components/iot-anomaly-detection/AnomalyDetection.py
@@ -10,12 +10,10 @@ class AnomalyDetection(object):
         print("Initializing...")
 
         # Variables needed for metric collection
-        self.V0=0
-        self.V1=0
-        self.V2=0
-        self.V3=0
-        self.V4=0
-        self.Prediction=0
+        self.actual=0
+        self.prediction=0
+        self.device_metric="na"
+
 
         self.model_file = os.environ.get('MODEL_FILE', 'model.joblib')
        
@@ -32,32 +30,30 @@ class AnomalyDetection(object):
             print(e)
             sys.exit() 
 
-    def predict(self, X, feature_names):
+
+  
+        
+    def predict(self, X, feature_names=None, meta=None):
         print(" Predict features: ", X)
         # print(" Features types: ", type(X),  type(X[0,0]))  
-    
-        self.V0=float(X[0,0])
-        self.V1=float(X[0,1])
-        self.V2=float(X[0,2])
-        self.V3=float(X[0,3])
-        self.V4=float(X[0,4])
 
-       
+
+        if meta:
+            # print(" device_metric: ", meta.get('device_metric'))
+            self.device_metric = meta.get('device_metric')
+    
+        self.actual=float(X[0,0])
 
         prediction = self.clf.predict(X)
-        self.Prediction=float(prediction)
+        self.prediction=float(prediction)
         print("Prediction: " , prediction)
         
         return prediction
 
     def metrics(self):
         return [
-            {"type":"GAUGE","key":"V0","value":self.V0},
-            {"type":"GAUGE","key":"V1","value":self.V1},
-            {"type":"GAUGE","key":"V2","value":self.V2},
-            {"type":"GAUGE","key":"V3","value":self.V3},
-            {"type":"GAUGE","key":"V4","value":self.V4},
-            {"type":"GAUGE","key":"Prediction","value":self.Prediction}
+            {"type":"GAUGE","key":"iot_anomaly_actual","value":self.actual, "tags": {"device_metric":self.device_metric}},
+            {"type":"GAUGE","key":"iot_anomaly_prediction","value":self.prediction, "tags": {"device_metric":self.device_metric}}
             ]
 
 
@@ -69,8 +65,10 @@ if __name__ == "__main__":
     print(" Features types: ", type(X),  type(X[0][0])) 
 
     ## prediction = p.clf.predict(X)
+    
+    meta_dict = {'device_metric': 'test1'}
 
-    prediction = p.predict(X,"")
+    prediction = p.predict(X,feature_names=None,meta=meta_dict)
     print(prediction)
     print(p.metrics())
 

--- a/components/iot-anomaly-detection/AnomalyDetection.py
+++ b/components/iot-anomaly-detection/AnomalyDetection.py
@@ -45,7 +45,7 @@ class AnomalyDetection(object):
        
 
         prediction = self.clf.predict(X)
-        self.Prediction=prediction
+        self.Prediction=float(prediction)
         print("Prediction: " , prediction)
         
         return prediction

--- a/components/iot-anomaly-detection/AnomalyDetection.py
+++ b/components/iot-anomaly-detection/AnomalyDetection.py
@@ -36,11 +36,13 @@ class AnomalyDetection(object):
         print(" Predict features: ", X)
         # print(" Features types: ", type(X),  type(X[0,0]))  
     
-        self.V0=X[0,0]
-        self.V1=X[0,1]
-        self.V2=X[0,2]
-        self.V3=X[0,3]
-        self.V4=X[0,4]
+        self.V0=float(X[0,0])
+        self.V1=float(X[0,1])
+        self.V2=float(X[0,2])
+        self.V3=float(X[0,3])
+        self.V4=float(X[0,4])
+
+       
 
         prediction = self.clf.predict(X)
         self.Prediction=prediction

--- a/components/iot-anomaly-detection/AnomalyDetection.py
+++ b/components/iot-anomaly-detection/AnomalyDetection.py
@@ -8,6 +8,15 @@ import time
 class AnomalyDetection(object):
     def __init__(self):
         print("Initializing...")
+
+        # Variables needed for metric collection
+        self.V0=0
+        self.V1=0
+        self.V2=0
+        self.V3=0
+        self.V4=0
+        self.Prediction=0
+
         self.model_file = os.environ.get('MODEL_FILE', 'model.joblib')
        
         print("Load modelfile: %s" % (self.model_file))
@@ -16,20 +25,40 @@ class AnomalyDetection(object):
             self.clf = load(open(self.model_file, 'rb'))
             print("Model file loaded: %s"% (self.model_file))
         except FileNotFoundError:
-            print("File does not exist in:", os. getcwd())
+            print("File does not exist in:", os.getcwd())
             sys.exit() 
-        except:
-            print("Coul dnot load model file! ", self.model_file, os. getcwd() )
+        except Exception as e:
+            print("Could not load model file! ", self.model_file, os.getcwd() )
+            print(e)
             sys.exit() 
 
     def predict(self, X, feature_names):
         print(" Predict features: ", X)
-        # print(" Features types: ", type(X),  type(X[0][0]))  
+        # print(" Features types: ", type(X),  type(X[0,0]))  
+    
+        self.V0=X[0,0]
+        self.V1=X[0,1]
+        self.V2=X[0,2]
+        self.V3=X[0,3]
+        self.V4=X[0,4]
 
         prediction = self.clf.predict(X)
+        self.Prediction=prediction
         print("Prediction: " , prediction)
         
         return prediction
+
+    def metrics(self):
+        return [
+            {"type":"GAUGE","key":"V0","value":self.V0},
+            {"type":"GAUGE","key":"V1","value":self.V1},
+            {"type":"GAUGE","key":"V2","value":self.V2},
+            {"type":"GAUGE","key":"V3","value":self.V3},
+            {"type":"GAUGE","key":"V4","value":self.V4},
+            {"type":"GAUGE","key":"Prediction","value":self.Prediction}
+            ]
+
+
 
 if __name__ == "__main__":
     p = AnomalyDetection()
@@ -37,7 +66,10 @@ if __name__ == "__main__":
     X = np.asarray([[16.1,  15.40,  15.32,  13.47,  17.70]], dtype=np.float32)
     print(" Features types: ", type(X),  type(X[0][0])) 
 
-    prediction = p.clf.predict(X)
+    ## prediction = p.clf.predict(X)
+
+    prediction = p.predict(X,"")
     print(prediction)
+    print(p.metrics())
 
 

--- a/components/iot-anomaly-detection/manifests/iot-anomaly-detection-metrics-svc.yaml
+++ b/components/iot-anomaly-detection/manifests/iot-anomaly-detection-metrics-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: anomaly-detection-metrics
+  namespace: iotdemo
+  labels:
+    seldon-app: anomaly-detection-predictor
+spec:
+  selector:
+    seldon-app: anomaly-detection-predictor
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 6000
+      targetPort: 6000

--- a/components/iot-anomaly-detection/manifests/kustomization.yaml
+++ b/components/iot-anomaly-detection/manifests/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - iot-anomaly-detection-route.yaml   
 - iot-anomaly-detection-is.yaml  
 - iot-anomaly-detection-seldon.yaml
+- iot-anomaly-detection-metrics-svc.yaml

--- a/components/iot-consumer/index.js
+++ b/components/iot-consumer/index.js
@@ -131,7 +131,7 @@ async function check_anomaly(id, value) {
         
         if (l.length == episode_length) {
 
-            var edgeAnomaly = { "data": { "ndarray": [l] }};
+            var edgeAnomaly = { "data": { "ndarray": [l] },"meta":{"device_metric":id}};
                 
             try {
                 console.log('*AD* ID: %s,  Val: %d', id, value );

--- a/components/iot-monitoring/README.md
+++ b/components/iot-monitoring/README.md
@@ -1,0 +1,3 @@
+# IoT Monitoring
+
+Generic Prometheus and Grafana manifests

--- a/components/iot-monitoring/manifests/anomaly-detection-servicemonitor.yaml
+++ b/components/iot-monitoring/manifests/anomaly-detection-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    seldon-app: anomaly-detection-predictor
+  name: manuela-anomaly-detection
+spec:
+  endpoints:
+  - interval: 30s
+    path: /prometheus
+    port: metrics
+  selector:
+    matchLabels:
+      seldon-app: anomaly-detection-predictor

--- a/components/iot-monitoring/manifests/grafana-instance.yaml
+++ b/components/iot-monitoring/manifests/grafana-instance.yaml
@@ -1,0 +1,26 @@
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  name: grafana
+  namespace: iotdemo
+spec:
+  config:
+    auth:
+      disable_signout_menu: true
+    auth.anonymous:
+      enabled: true
+    log:
+      level: warn
+      mode: console
+    security:
+      admin_password: secret
+      admin_user: root
+  ingress:
+    enabled: true
+  dashboardLabelSelector:
+    - matchExpressions:
+        - key: app
+          operator: In
+          values:
+            - grafana
+

--- a/components/iot-monitoring/manifests/grafana-prometheus-datasource.yaml
+++ b/components/iot-monitoring/manifests/grafana-prometheus-datasource.yaml
@@ -1,0 +1,17 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: manuela-prometheus
+  namespace: iotdemo
+spec:
+  datasources:
+    - access: proxy
+      editable: true
+      isDefault: true
+      jsonData:
+        timeInterval: 5s
+      name: prometheus
+      type: prometheus
+      url: 'http://prometheus-operated:9090'
+      version: 1
+  name: manuela-prometheus.yaml

--- a/components/iot-monitoring/manifests/kustomization.yaml
+++ b/components/iot-monitoring/manifests/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources: 
+
+# Base configuration
+- prometheus-instance.yaml
+- prometheus-route.yaml
+- grafana-instance.yaml
+- grafana-prometheus-datasource.yaml
+
+# Scrape data
+- anomaly-detection-servicemonitor.yaml
+- manuela-seldon-servicemonitor.yaml
+
+# Dashboards
+- prediction-analytics-aio-dashboard.yaml
+- sensor-custom-seldon-metrics-dashboards.yaml
+- prediction-analytics-seldon-core-1.2.2.yaml

--- a/components/iot-monitoring/manifests/manuela-seldon-servicemonitor.yaml
+++ b/components/iot-monitoring/manifests/manuela-seldon-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    seldon-app: anomaly-detection-predictor
+  name: manuela-seldon
+spec:
+  endpoints:
+  - interval: 30s
+    path: /prometheus
+    port: http
+  selector:
+    matchLabels:
+      seldon-app: anomaly-detection-predictor

--- a/components/iot-monitoring/manifests/prediction-analytics-aio-dashboard.yaml
+++ b/components/iot-monitoring/manifests/prediction-analytics-aio-dashboard.yaml
@@ -1,0 +1,1164 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: prediction-analytics-aio-dashboard
+  labels:
+    app: grafana
+  namespace: iotdemo
+spec:
+  json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Based Prediction Analytics Helm. Modified for 1.2.2. Seldon Operator",
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 7,
+      "iteration": 1603889019320,
+      "links": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 2,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "hiddenSeries": false,
+          "id": 46,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": true,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "iot_anomaly_actual",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Sensor data",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "hiddenSeries": false,
+          "id": 48,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": false,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "iot_anomaly_prediction",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Anomaly Predictions",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
+          "id": 40,
+          "panels": [],
+          "repeat": null,
+          "title": "Heading",
+          "type": "row"
+        },
+        {
+          "content": "<div class=\"text-center dashboard-header\">\n  <span>Seldon Core API Dashboard</span>\n</div>",
+          "datasource": null,
+          "gridPos": {
+            "h": 2,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 27,
+          "links": [],
+          "mode": "html",
+          "options": {},
+          "title": "",
+          "type": "text"
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 11
+          },
+          "id": 41,
+          "panels": [],
+          "repeat": null,
+          "title": "Global Counts",
+          "type": "row"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "prometheus",
+          "format": "ops",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 0,
+            "y": 12
+          },
+          "id": 16,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "round(sum(irate(seldon_api_executor_server_requests_seconds_count[1m])),0.001)",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 20
+            }
+          ],
+          "thresholds": "",
+          "title": "Global Request Rate",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "prometheus",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 6,
+            "y": 12
+          },
+          "id": 17,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(seldon_api_executor_server_requests_seconds_count{status!~\"5.*\"}[1m])) / sum(rate(seldon_api_executor_server_requests_seconds_count[1m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 20
+            }
+          ],
+          "thresholds": "",
+          "title": "Success",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "prometheus",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 12,
+            "y": 12
+          },
+          "id": 37,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(seldon_api_executor_client_requests_seconds_count{deployment_name=~\"$deployment\",status!~\"5.*\"}[1m])) / sum(rate(seldon_api_executor_client_requests_seconds_count{deployment_name=~\"$deployment\"}[1m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 20
+            }
+          ],
+          "thresholds": "",
+          "title": "Success ($deployment)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "prometheus",
+          "format": "ops",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 18,
+            "y": 12
+          },
+          "id": 36,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "round(sum(irate(seldon_api_executor_client_requests_seconds_count{deployment_name=~'$deployment'}[1m])), 0.001)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 20
+            }
+          ],
+          "thresholds": "",
+          "title": "Request Rate ($deployment)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          },
+          "id": 43,
+          "panels": [],
+          "repeat": null,
+          "title": "Models",
+          "type": "row"
+        },
+        {
+          "content": "<div class=\"text-center dashboard-header\">\n  <span>Models</span>\n</div>",
+          "datasource": null,
+          "gridPos": {
+            "h": 2,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "id": 8,
+          "links": [],
+          "mode": "html",
+          "options": {},
+          "title": "",
+          "type": "text"
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "id": 44,
+          "panels": [],
+          "repeat": "model_image",
+          "scopedVars": {
+            "model_image": {
+              "selected": false,
+              "text": "iot-anomaly-detection",
+              "value": "iot-anomaly-detection"
+            }
+          },
+          "title": "Model Metrics $model_image",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 18,
+            "x": 0,
+            "y": 19
+          },
+          "hiddenSeries": false,
+          "id": 7,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "scopedVars": {
+            "model_image": {
+              "selected": false,
+              "text": "iot-anomaly-detection",
+              "value": "iot-anomaly-detection"
+            }
+          },
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(seldon_api_executor_client_requests_seconds_count{model_name=~\"$model_name\",model_version=~\"$model_version\",model_image=~\"$model_image\",predictor_name=~\"$predictor\",predictor_version=~\"$version\"}[1m])) by (model_name,predictor_name,predictor_version,model_image,model_version,service)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{predictor_name}}:{{predictor_version}} ({{model_name}} {{model_image}} : {{model_version}}) {{service}}",
+              "metric": "io_seldon_apife_api_rest_RestClientController_home_snapshot_75thPercentile",
+              "refId": "A",
+              "step": 2
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Reqs/sec to $model_image",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": null,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 18,
+            "y": 19
+          },
+          "id": 50,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.5.1",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "model_image": {
+              "selected": false,
+              "text": "iot-anomaly-detection",
+              "value": "iot-anomaly-detection"
+            }
+          },
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(rate(seldon_api_executor_client_requests_seconds_count{model_name=~\"$model_name\",model_version=~\"$model_version\",model_image=~\"$model_image\",predictor_name=~\"$predictor\",predictor_version=~\"$version\"}[1m])) by (model_name,predictor_name,predictor_version,model_image,model_version,service)",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Reqs/sec to $model_image",
+          "type": "singlestat",
+          "valueFontSize": "110%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 28
+          },
+          "hiddenSeries": false,
+          "id": 11,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "scopedVars": {
+            "model_image": {
+              "selected": false,
+              "text": "iot-anomaly-detection",
+              "value": "iot-anomaly-detection"
+            }
+          },
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(seldon_api_executor_client_requests_seconds_bucket{exported_service=~\".*[Pp]redict\",model_image=~\"$model_image\",predictor_name=~\"$predictor\",predictor_version=~\"$version\",model_name=~\"$model_name\",model_version=~\"$model_version\"}[1m])) by (predictor_name,predictor_version,model_name,model_image,model_version,service,le))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{predictor_name}}:{{predictor_version}} {{model_name}} {{model_image}}: {{model_version}} (p50)",
+              "metric": "",
+              "refId": "E",
+              "step": 2
+            },
+            {
+              "expr": "histogram_quantile(0.75, sum(rate(seldon_api_executor_client_requests_seconds_bucket{exported_service=~\".*[Pp]redict\",model_image=~\"$model_image\",predictor_name=~\"$predictor\",predictor_version=~\"$version\",model_name=~\"$model_name\",model_version=~\"$model_version\"}[1m])) by (predictor_name,predictor_version,model_name,model_image,model_version,service,le))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{predictor_name}}:{{predictor_version}} {{model_name}} {{model_image}}:{{model_version}} {{service}} (p75)",
+              "metric": "",
+              "refId": "B",
+              "step": 2
+            },
+            {
+              "expr": "histogram_quantile(0.9, sum(rate(seldon_api_executor_client_requests_seconds_bucket{exported_service=~\".*[Pp]redict\",model_image=~\"$model_image\",predictor_name=~\"$predictor\",predictor_version=~\"$version\",model_name=~\"$model_name\",model_version=~\"$model_version\"}[1m])) by (predictor_name,predictor_version,model_name,model_image,model_version, service,le))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{predictor_name}}:{{predictor_version}} {{model_name}} {{model_image}}:{{model_version}}  {{service}} (p90)",
+              "metric": "",
+              "refId": "A",
+              "step": 2
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(seldon_api_executor_client_requests_seconds_bucket{exported_service=~\".*[Pp]redict\",model_image=~\"$model_image\",predictor_name=~\"$predictor\",predictor_version=~\"$version\",model_name=~\"$model_name\",model_version=~\"$model_version\"}[1m])) by (predictor_name,predictor_version,model_name,model_image,model_version,service,le))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{predictor_name}}:{{predictor_version}} {{model_name}} {{model_image}}:{{model_version}} {{service}} (p95)",
+              "metric": "",
+              "refId": "C",
+              "step": 2
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(seldon_api_executor_client_requests_seconds_bucket{exported_service=~\".*[Pp]redict\",model_image=~\"$model_image\",predictor_name=~\"$predictor\",predictor_version=~\"$version\",model_name=~\"$model_name\",model_version=~\"$model_version\"}[1m])) by (predictor_name,predictor_version,model_name,model_image,model_version,service,le))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{predictor_name}}:{{predictor_version}} {{model_name}} {{model_image}}:{{model_version}} {{service}} (p99)",
+              "metric": "",
+              "refId": "D",
+              "step": 2
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "$model_image Latency",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "refresh": "5s",
+      "schemaVersion": 21,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": ".*",
+            "current": {
+              "text": "All",
+              "value": [
+                "$__all"
+              ]
+            },
+            "datasource": "prometheus",
+            "definition": "label_values(seldon_api_executor_client_requests_seconds_count,deployment_name)",
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": true,
+            "name": "deployment",
+            "options": [],
+            "query": "label_values(seldon_api_executor_client_requests_seconds_count,deployment_name)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": "prometheus",
+            "definition": "label_values(seldon_api_executor_client_requests_seconds_count,predictor_name)",
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": true,
+            "name": "predictor",
+            "options": [],
+            "query": "label_values(seldon_api_executor_client_requests_seconds_count,predictor_name)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": "prometheus",
+            "definition": "label_values(seldon_api_executor_client_requests_seconds_count,predictor_version)",
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": true,
+            "name": "version",
+            "options": [],
+            "query": "label_values(seldon_api_executor_client_requests_seconds_count,predictor_version)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": "prometheus",
+            "definition": "label_values(seldon_api_executor_client_requests_seconds_count,model_name)",
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": true,
+            "name": "model_name",
+            "options": [],
+            "query": "label_values(seldon_api_executor_client_requests_seconds_count,model_name)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": "prometheus",
+            "definition": "label_values(seldon_api_executor_client_requests_seconds_count,model_image)",
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": true,
+            "name": "model_image",
+            "options": [],
+            "query": "label_values(seldon_api_executor_client_requests_seconds_count,model_image)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": "prometheus",
+            "definition": "label_values(seldon_api_executor_client_requests_seconds_count,model_version)",
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": true,
+            "name": "model_version",
+            "options": [],
+            "query": "label_values(seldon_api_executor_client_requests_seconds_count,model_version)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-15m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "browser",
+      "title": "Prediction Analytics Manuela AIO",
+      "uid": "eL9UN_pMz",
+      "version": 3
+    }  
+  name: prediction-analytics-aio-dashboard.json

--- a/components/iot-monitoring/manifests/prediction-analytics-seldon-core-1.2.2.yaml
+++ b/components/iot-monitoring/manifests/prediction-analytics-seldon-core-1.2.2.yaml
@@ -1,0 +1,1465 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: prediction-analytics-seldon-core-1.2.2
+  labels:
+    app: grafana
+  namespace: iotdemo
+spec:
+  json: |
+    {
+        "annotations": {
+          "list": [
+            {
+              "builtIn": 1,
+              "datasource": "-- Grafana --",
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "type": "dashboard"
+            }
+          ]
+        },
+        "description": "Prediction Analytics base on original. Changed for Seldon 1.2.2 operator",
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "id": 5,
+        "iteration": 1603885099539,
+        "links": [],
+        "panels": [
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "id": 29,
+            "panels": [],
+            "repeat": null,
+            "title": "Heading",
+            "type": "row"
+          },
+          {
+            "content": "<div class=\"text-center dashboard-header\">\n  <span>Seldon Deploy Prediction API Dashboard</span>\n</div>",
+            "datasource": null,
+            "gridPos": {
+              "h": 3,
+              "w": 22,
+              "x": 0,
+              "y": 1
+            },
+            "id": 27,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "title": "",
+            "type": "text"
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 4
+            },
+            "id": 30,
+            "panels": [],
+            "repeat": null,
+            "title": "Global Counts",
+            "type": "row"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "prometheus",
+            "format": "ops",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 3,
+              "w": 6,
+              "x": 0,
+              "y": 5
+            },
+            "id": 16,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": true,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "round(sum(irate(seldon_api_executor_server_requests_seconds_count[1m])), 0.001)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 20
+              }
+            ],
+            "thresholds": "",
+            "title": "Global Request Rate",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "prometheus",
+            "format": "percentunit",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 3,
+              "w": 6,
+              "x": 6,
+              "y": 5
+            },
+            "id": 17,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": true,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(rate(seldon_api_executor_server_requests_seconds_count{status!~\"5.*\"}[1m])) / sum(rate(seldon_api_executor_server_requests_seconds_count[1m]))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 20
+              }
+            ],
+            "thresholds": "",
+            "title": "Success",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "prometheus",
+            "format": "ops",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 3,
+              "w": 6,
+              "x": 12,
+              "y": 5
+            },
+            "id": 18,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": true,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(irate(seldon_api_executor_server_requests_seconds_count{status=~\"4.*\"}[1m])) ",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 20
+              }
+            ],
+            "thresholds": "",
+            "title": "4xxs",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "prometheus",
+            "format": "ops",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 3,
+              "w": 6,
+              "x": 18,
+              "y": 5
+            },
+            "id": 19,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "options": {},
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": true,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(irate(seldon_api_executor_server_requests_seconds_count{status=~\"5.*\"}[1m])) ",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 20
+              }
+            ],
+            "thresholds": "",
+            "title": "5xxs",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 8
+            },
+            "id": 31,
+            "panels": [],
+            "repeat": null,
+            "title": "Dashboard Row",
+            "type": "row"
+          },
+          {
+            "content": "<div class=\"text-center dashboard-header\">\n  <span>External API</span>\n</div>",
+            "datasource": null,
+            "gridPos": {
+              "h": 3,
+              "w": 24,
+              "x": 0,
+              "y": 9
+            },
+            "id": 9,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "title": "",
+            "type": "text"
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 12
+            },
+            "id": 32,
+            "panels": [],
+            "repeat": null,
+            "title": "API Percentiles",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 0,
+              "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+              "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "round(sum(rate(seldon_api_executor_server_requests_seconds_count{exported_service=~\"predictions\",namespace=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",code=\"200\"}[1m]))by (project_name, deployment_name, deployment_version, exported_service, code),0.0001)",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}} -> {{uri}} ",
+                "metric": "",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Prediction API req/sec",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 10,
+              "x": 8,
+              "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 26,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+              "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(seldon_api_ingress_server_feedback_reward_total{project_name=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\"}[1m])/rate(seldon_api_ingress_server_feedback_total{project_name=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\"}[1m])",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}} ",
+                "metric": "",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Feedback API Average Reward",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 6,
+              "x": 18,
+              "y": 13
+            },
+            "hiddenSeries": false,
+            "id": 25,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+              "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(seldon_api_ingress_server_requests_duration_seconds_count{status=~\"5.*\"}[1m]))  by (project_name, deployment_name, deployment_version, uri)",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 4
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "5xxs by URI",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 20
+            },
+            "id": 33,
+            "panels": [],
+            "repeat": null,
+            "title": "Dashboard Row",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 21
+            },
+            "hiddenSeries": false,
+            "id": 5,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": false,
+              "hideZero": true,
+              "max": false,
+              "min": false,
+              "rightSide": true,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+              "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.5, sum(rate(seldon_api_executor_server_requests_seconds_bucket{exported_service=~\"predictions\",namespace=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",code=\"200\"}[1m])) by (namespace, deployment_name, deployment_version, exported_service, code,le))",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}} -> {{uri}} : {{status}} (p50)",
+                "refId": "A",
+                "step": 2
+              },
+              {
+                "expr": "histogram_quantile(0.75, sum(rate(seldon_api_executor_server_requests_seconds_bucket{exported_service=~\"predictions\",namespace=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",code=\"200\"}[1m])) by (namespace, deployment_name, deployment_version, exported_service, code,le))",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}} -> {{uri}} : {{status}} (p75)",
+                "metric": "",
+                "refId": "B",
+                "step": 2
+              },
+              {
+                "expr": "histogram_quantile(0.9, sum(rate(seldon_api_executor_server_requests_seconds_bucket{exported_service=~\"predictions\",namespace=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",code=\"200\"}[1m])) by (namespace, deployment_name, deployment_version, exported_service, code,le))",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}} -> {{uri}} : {{status}} (p90)",
+                "refId": "C",
+                "step": 2
+              },
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(seldon_api_executor_server_requests_seconds_bucket{exported_service=~\"predictions\",namespace=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",code=\"200\"}[1m])) by (namespace, deployment_name, deployment_version, exported_service, code,le))",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}} -> {{uri}} : {{status}} (p99)",
+                "refId": "D",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Prediction API Latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 29
+            },
+            "id": 34,
+            "panels": [],
+            "repeat": null,
+            "title": "Predictive Units",
+            "type": "row"
+          },
+          {
+            "content": "<div class=\"text-center dashboard-header\">\n  <span>Models</span>\n</div>",
+            "datasource": null,
+            "gridPos": {
+              "h": 3,
+              "w": 24,
+              "x": 0,
+              "y": 30
+            },
+            "id": 8,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "title": "",
+            "type": "text"
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 33
+            },
+            "id": 35,
+            "panels": [],
+            "repeat": "model_image",
+            "title": "Model Metrics",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 9,
+              "w": 8,
+              "x": 0,
+              "y": 34
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+              "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(rate(seldon_api_executor_client_requests_seconds_count{model_image=~\"$model_image\",namespace=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",predictor_name=~\"$predictor\",predictor_version=~\"$version\"}[1m])) by (namespace,deployment_name,deployment_version,predictor_name,predictor_version,model_image,model_version,model_name)",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}}/{{predictor_name}}:{{predictor_version}} ({{model_name}} {{model_image}} : {{model_version}})",
+                "metric": "io_seldon_apife_api_rest_RestClientController_home_snapshot_75thPercentile",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Reqs/sec to $model_image",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 9,
+              "w": 8,
+              "x": 8,
+              "y": 34
+            },
+            "hiddenSeries": false,
+            "id": 28,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+              "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(seldon_api_model_feedback_reward_total{project_name=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",predictor_name=~\"$predictor\",predictor_version=~\"$version\",model_image=~\"$model_image\"}[1m])/rate(seldon_api_model_feedback_total{project_name=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",predictor_name=~\"$predictor\",predictor_version=~\"$version\",model_image=~\"$model_image\",model_version=~\"$model_version\"}[1m])",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}}/{{predictor_name}}:{{predictor_version}}  {{model_name}} {{model_image}} : {{model_version}}",
+                "metric": "",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$model_image Reward",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 9,
+              "w": 8,
+              "x": 16,
+              "y": 34
+            },
+            "hiddenSeries": false,
+            "id": 11,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+              "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.5, sum(rate(seldon_api_executor_client_requests_seconds_bucket{exported_service=~\"/predict\",model_image=~\"$model_image\",namespace=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",predictor_name=~\"$predictor\",predictor_version=~\"$version\"}[1m])) by (namespace,deployment_name,deployment_version,predictor_name,predictor_version,model_name,model_image,model_version,le))",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}}/{{predictor_name}}:{{predictor_version}} {{model_name}}: {{model_version}} (p50)",
+                "metric": "",
+                "refId": "E",
+                "step": 2
+              },
+              {
+                "expr": "histogram_quantile(0.75, sum(rate(seldon_api_executor_client_requests_seconds_bucket{exported_service=~\"/predict\",model_image=~\"$model_image\",namespace=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",predictor_name=~\"$predictor\",predictor_version=~\"$version\"}[1m])) by (namespace,deployment_name,deployment_version,predictor_name,predictor_version,model_name,model_image,model_version,le))",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}}/{{predictor_name}}:{{predictor_version}} {{model_name}} : {{model_version}} (p75)",
+                "metric": "",
+                "refId": "B",
+                "step": 2
+              },
+              {
+                "expr": "histogram_quantile(0.9, sum(rate(seldon_api_executor_client_requests_seconds_bucket{exported_service=~\"/predict\",model_image=~\"$model_image\",namespace=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",predictor_name=~\"$predictor\",predictor_version=~\"$version\"}[1m])) by (namespace,deployment_name,deployment_version,predictor_name,predictor_version,model_name,model_image,model_version,le))",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}}/{{predictor_name}}:{{predictor_version}} {{model_name}}: {{model_version}} (p90)",
+                "metric": "",
+                "refId": "A",
+                "step": 2
+              },
+              {
+                "expr": "histogram_quantile(0.95, sum(rate(seldon_api_executor_client_requests_seconds_bucket{exported_service=~\"/predict\",model_image=~\"$model_image\",namespace=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",predictor_name=~\"$predictor\",predictor_version=~\"$version\"}[1m])) by (namespace,deployment_name,deployment_version,predictor_name,predictor_version,model_name,model_image,model_version,le))",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}}/{{predictor_name}}:{{predictor_version}} {{model_name}}: {{model_version}} (p95)",
+                "metric": "",
+                "refId": "C",
+                "step": 2
+              },
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(seldon_api_executor_client_requests_seconds_bucket{exported_service=~\"/predict\",model_image=~\"$model_image\",namespace=~\"$project\",deployment_name=~\"$deployment\",deployment_version=~\"$deployment_version\",predictor_name=~\"$predictor\",predictor_version=~\"$version\"}[1m])) by (namespace,deployment_name,deployment_version,predictor_name,predictor_version,model_name,model_image,model_version,le))",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{project_name}}/{{deployment_name}}:{{deployment_version}}/{{predictor_name}}:{{predictor_version}} {{model_name}}: {{model_version}} (p99)",
+                "metric": "",
+                "refId": "D",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$model_image Latency",
+            "tooltip": {
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "refresh": "5s",
+        "schemaVersion": 21,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+          "list": [
+            {
+              "allValue": ".*",
+              "current": {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+              },
+              "datasource": "prometheus",
+              "definition": "label_values(seldon_api_executor_server_requests_seconds_count,namespace)",
+              "hide": 0,
+              "includeAll": true,
+              "label": null,
+              "multi": true,
+              "name": "project",
+              "options": [],
+              "query": "label_values(seldon_api_executor_server_requests_seconds_count,namespace)",
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 0,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            },
+            {
+              "allValue": ".*",
+              "current": {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+              },
+              "datasource": "prometheus",
+              "definition": "",
+              "hide": 0,
+              "includeAll": true,
+              "label": null,
+              "multi": true,
+              "name": "deployment",
+              "options": [],
+              "query": "label_values(seldon_api_ingress_server_requests_duration_seconds_count,deployment_name)",
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 0,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            },
+            {
+              "allValue": ".*",
+              "current": {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+              },
+              "datasource": "prometheus",
+              "definition": "",
+              "hide": 0,
+              "includeAll": true,
+              "label": null,
+              "multi": true,
+              "name": "deployment_version",
+              "options": [],
+              "query": "label_values(seldon_api_ingress_server_requests_duration_seconds_count,deployment_version)",
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 0,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            },
+            {
+              "allValue": ".*",
+              "current": {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+              },
+              "datasource": "prometheus",
+              "definition": "",
+              "hide": 0,
+              "includeAll": true,
+              "label": null,
+              "multi": true,
+              "name": "predictor",
+              "options": [],
+              "query": "label_values(seldon_api_engine_client_requests_duration_seconds_count,predictor_name)",
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 0,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            },
+            {
+              "allValue": ".*",
+              "current": {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+              },
+              "datasource": "prometheus",
+              "definition": "",
+              "hide": 0,
+              "includeAll": true,
+              "label": null,
+              "multi": true,
+              "name": "version",
+              "options": [],
+              "query": "label_values(seldon_api_engine_client_requests_duration_seconds_count,predictor_version)",
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 0,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            },
+            {
+              "allValue": ".*",
+              "current": {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+              },
+              "datasource": "prometheus",
+              "definition": "",
+              "hide": 0,
+              "includeAll": true,
+              "label": null,
+              "multi": true,
+              "name": "model_image",
+              "options": [],
+              "query": "label_values(seldon_api_engine_client_requests_duration_seconds_count,model_image)",
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 0,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            },
+            {
+              "allValue": ".*",
+              "current": {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+              },
+              "datasource": "prometheus",
+              "definition": "",
+              "hide": 0,
+              "includeAll": true,
+              "label": null,
+              "multi": true,
+              "name": "model_version",
+              "options": [],
+              "query": "label_values(seldon_api_engine_client_requests_duration_seconds_count,model_version)",
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 0,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            }
+          ]
+        },
+        "time": {
+          "from": "now-15m",
+          "to": "now"
+        },
+        "timepicker": {
+          "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+          ],
+          "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+          ]
+        },
+        "timezone": "browser",
+        "title": "Prediction Analytics (new)",
+        "uid": "wjAOklpGz",
+        "version": 4
+      }
+  name: prediction-analytics-seldon-core-1.2.2.json

--- a/components/iot-monitoring/manifests/prometheus-instance.yaml
+++ b/components/iot-monitoring/manifests/prometheus-instance.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+  labels:
+    prometheus: k8s
+  namespace: iotdemo
+spec:
+  serviceAccountName: prometheus-k8s
+  serviceMonitorSelector: {}
+  alerting:
+    alertmanagers:
+      - namespace: monitoring
+        name: alertmanager-main
+        port: web
+  securityContext: {}
+  replicas: 2
+  ruleSelector: {}

--- a/components/iot-monitoring/manifests/prometheus-route.yaml
+++ b/components/iot-monitoring/manifests/prometheus-route.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: prometheus
+spec:
+  port:
+    targetPort: web
+  to:
+    kind: Service
+    name: prometheus-operated
+    weight: 100
+  wildcardPolicy: None
+status: {}

--- a/components/iot-monitoring/manifests/sensor-custom-seldon-metrics-dashboards.yaml
+++ b/components/iot-monitoring/manifests/sensor-custom-seldon-metrics-dashboards.yaml
@@ -1,0 +1,234 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: sensor-custom-seldon-metrics-dashboards
+  labels:
+    app: grafana
+  namespace: iotdemo
+spec:
+  json: |
+    {
+        "annotations": {
+          "list": [
+            {
+              "builtIn": 1,
+              "datasource": "-- Grafana --",
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "type": "dashboard"
+            }
+          ]
+        },
+        "description": "Seldon Custom Metrics",
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "id": 4,
+        "links": [],
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 9,
+              "w": 12,
+              "x": 0,
+              "y": 0
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+              "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "iot_anomaly_actual",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Actual sensor data",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 9
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": false,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+              "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "iot_anomaly_prediction",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Anomaly Predictions",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "refresh": "5s",
+        "schemaVersion": 21,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+          "list": []
+        },
+        "time": {
+          "from": "now-15m",
+          "to": "now"
+        },
+        "timepicker": {
+          "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+          ]
+        },
+        "timezone": "",
+        "title": "Sensor Data Anomaly Detection",
+        "uid": "nxPIR_tGz",
+        "version": 5
+    } 
+  name: sensor-custom-seldon-metrics-dashboards.json

--- a/components/kustomization.yaml
+++ b/components/kustomization.yaml
@@ -10,4 +10,5 @@ bases:
 # Open data hub is optional
 - iot-anomaly-detection/manifests
 
-
+# Monitoring is optional (really?)
+- iot-monitoring/manifests

--- a/operator_subscriptions/monitoring/grafana-operator-subs.yaml
+++ b/operator_subscriptions/monitoring/grafana-operator-subs.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: grafana-operator
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: grafana-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: grafana-operator.v3.5.0

--- a/operator_subscriptions/monitoring/kustomization.yaml
+++ b/operator_subscriptions/monitoring/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- grafana-operator-subs.yaml  
+- prometheus-operator-subs.yaml

--- a/operator_subscriptions/monitoring/prometheus-operator-subs.yaml
+++ b/operator_subscriptions/monitoring/prometheus-operator-subs.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: prometheus
+spec:
+  channel: beta
+  installPlanApproval: Automatic
+  name: prometheus
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: prometheusoperator.0.37.0


### PR DESCRIPTION
Enhanced Seldon Python wrapper with custom metrics
Additional route for anomaly detection to enable scraping
Grafana operator, datasource and dashboards
Prometheus operator and service monitors
Add meta data in Seldon REST WS call in iot-consumer
